### PR TITLE
Refactor CLI auth flow to reuse HttpClient

### DIFF
--- a/src/Keydral.CLI/Services/AuthenticationService.cs
+++ b/src/Keydral.CLI/Services/AuthenticationService.cs
@@ -61,17 +61,18 @@ internal class OAuth2ErrorResponse
 /// </summary>
 public class AuthenticationService
 {
+    private static readonly HttpClient SharedHttpClient = new();
     private readonly string _keycloakUrl;
     private readonly string _realm;
     private readonly string _clientId;
     private readonly HttpClient _httpClient;
 
-    public AuthenticationService(string keycloakUrl, string realm, string clientId)
+    public AuthenticationService(string keycloakUrl, string realm, string clientId, HttpClient? httpClient = null)
     {
         _keycloakUrl = keycloakUrl.TrimEnd('/');
         _realm = realm;
         _clientId = clientId;
-        _httpClient = new HttpClient();
+        _httpClient = httpClient ?? SharedHttpClient;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- reuse a shared HttpClient in the CLI AuthenticationService instead of creating one per instance
- keep the service extensible with an optional HttpClient constructor parameter

## Validation
- dotnet build Keydral.sln
- dotnet test Keydral.sln --no-build

## Related
- Closes #17
